### PR TITLE
Ch 80 fix booking repository overlapping bookings query error

### DIFF
--- a/ChargeUnity/backend/src/main/java/tqs/ChargeUnity/repository/BookingRepository.java
+++ b/ChargeUnity/backend/src/main/java/tqs/ChargeUnity/repository/BookingRepository.java
@@ -7,6 +7,9 @@ import tqs.ChargeUnity.model.Booking;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 @Repository
 public interface BookingRepository extends JpaRepository<Booking, Integer> {
 
@@ -23,7 +26,8 @@ public interface BookingRepository extends JpaRepository<Booking, Integer> {
     // Optional: Retrieve all bookings for a charger between two dates (useful for operator dashboards)
     List<Booking> findByChargerIdAndStartTimeBetween(Integer chargerId, LocalDateTime start, LocalDateTime end);
 
-    List<Booking> findOverlappingBookings(int chargerId, LocalDateTime start, LocalDateTime end);
+    @Query("SELECT b FROM Booking b WHERE b.charger.id = :chargerId AND b.startTime < :end AND b.endTime > :start")
+    List<Booking> findOverlappingBookings(@Param("chargerId") int chargerId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     List<Booking> findByChargerId(int chargerId);
 }


### PR DESCRIPTION
# Description
The `BookingRepository` interface caused application startup failures due to a missing custom query for the `findOverlappingBookings` method.
Spring Data JPA could not derive a query from the method name, resulting in a `QueryCreationException`.

## Context
Jira Issue: [CH-80](https://tqs-chargeunity.atlassian.net/browse/CH-80)

[CH-80]: https://tqs-chargeunity.atlassian.net/browse/CH-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ